### PR TITLE
Render Missions in Profile

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,12 +6,14 @@ import Missions from './components/Missions';
 import Navbar from './components/Navbar';
 import Profile from './components/Profile';
 import Rockets from './components/Rockets';
+import { fetchMissions } from './redux/mission/missionSlice';
 import { fetchRockets } from './redux/rockets/rocketSlice';
 
 function App() {
   const dispatch = useDispatch();
   useEffect(() => {
     dispatch(fetchRockets());
+    dispatch(fetchMissions());
   }, [dispatch]);
 
   return (

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,15 +1,12 @@
 import { useDispatch, useSelector } from 'react-redux';
 import Table from 'react-bootstrap/Table';
-import { useEffect } from 'react';
 import { Badge } from 'react-bootstrap';
-import { fetchMissions, joinMission, leaveMission } from '../redux/mission/missionSlice';
+import { joinMission, leaveMission } from '../redux/mission/missionSlice';
 
 const Missions = () => {
   const { missions } = useSelector((state) => state.missions);
   const dispatch = useDispatch();
-  useEffect(() => {
-    dispatch(fetchMissions());
-  }, [dispatch]);
+
   return (
     <div>
       Missions

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -1,14 +1,33 @@
+import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
 const Profile = () => {
   const { missions } = useSelector((state) => state.missions);
+  const [joinedMissions, setJoinedMissions] = useState([]);
+
+  useEffect(() => {
+    const filteredMissions = missions.filter((mission) => mission.joined);
+    setJoinedMissions(filteredMissions);
+  }, [missions]);
+
+  if (!joinedMissions.length) {
+    return (
+      <div className="missionBox">
+        <h1>My Missions</h1>
+        <div className="noJoined">No Missions Joined</div>
+      </div>
+    );
+  }
   return (
     <div>
       Profile
       <h1>My Missions</h1>
       <div className="missionBox">
-        {missions.filter((mission) => mission.joined)
-          .map((mission) => <div key={mission.mission_id} className="joinedMission">{mission.mission_name}</div>)}
+        {joinedMissions.map((mission) => (
+          <div key={mission.mission_id} className="joinedMission">
+            {mission.mission_name}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -1,5 +1,17 @@
-const Profile = () => (
-  <div>Profile</div>
-);
+import { useSelector } from 'react-redux';
+
+const Profile = () => {
+  const { missions } = useSelector((state) => state.missions);
+  return (
+    <div>
+      Profile
+      <h1>My Missions</h1>
+      <div className="missionBox">
+        {missions.filter((mission) => mission.joined)
+          .map((mission) => <div key={mission.mission_id} className="joinedMission">{mission.mission_name}</div>)}
+      </div>
+    </div>
+  );
+};
 
 export default Profile;


### PR DESCRIPTION
## In this Milestone, I made the following additions ➕ ➕ 🟢

### - Rendered a list of all joined missions (using filter()) on the "My profile" page. 🎨 
  - Added missions state to profile component via `useSelector()`.
  - Filtered missions for joined missions using `filter()`.
  - Displayed **mission_name(s)** of all joined missions using `map()`. 
  - Updated Profile component with local state to show message for no joined Mission.
  - Fixed Linter errors 🧰



